### PR TITLE
fix(deps): désactiver Renovate sur react-native pour éviter conflit E…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,7 @@
       "matchPackageNames": [
         "react",
         "react-dom",
+        "react-native",
         "react-native-svg",
         "react-test-renderer"
       ],


### PR DESCRIPTION
…RESOLVE

Renovate proposait un bump isolé de react-native (0.85.3 -> 0.86.2, PR #288), incompatible avec la version bundlée par le SDK Expo installé, causant un échec npm ci en CI. react-native rejoint la liste des packages déjà exclus (react, react-dom, react-native-svg, react-test-renderer) dont la version doit rester synchronisée exclusivement via l'automatisation SDK Expo.